### PR TITLE
DO NOT MERGE: Make use of specified relationship for post-compositions.

### DIFF
--- a/zpgen/src/main/java/de/charite/zpgen/ZFINEntry.java
+++ b/zpgen/src/main/java/de/charite/zpgen/ZFINEntry.java
@@ -17,12 +17,18 @@ public class ZFINEntry {
 
 	public String entity1SubtermId;
 	public String entity1SubtermName;
+	
+	public String entity1RelationshipId;
+	public String entity1RelationshipName;
 
 	public String entity2SupertermId;
 	public String entity2SupertermName;
 
 	public String entity2SubtermId;
 	public String entity2SubtermName;
+	
+	public String entity2RelationshipId;
+	public String entity2RelationshipName;
 
 	public String patoID;
 	public String patoName;

--- a/zpgen/src/main/java/de/charite/zpgen/ZFINWalker.java
+++ b/zpgen/src/main/java/de/charite/zpgen/ZFINWalker.java
@@ -53,11 +53,15 @@ public class ZFINWalker {
 	private static final int PHENO_GENOTYPES_COLUMN_ZFIN_GENO_ID = 0;
 	private static final int PHENO_GENOTYPES_COLUMN_TERM1_SUBTERM_ID = 6;
 	private static final int PHENO_GENOTYPES_COLUMN_TERM1_SUBTERM_NAME = 7;
+	private static final int PHENO_GENOTYPES_COLUMN_TERM1_RELATIONSHIP_ID = 8;
+	private static final int PHENO_GENOTYPES_COLUMN_TERM1_RELATIONSHIP_NAME = 9;
 	private static final int PHENO_GENOTYPES_COLUMN_TERM1_SUPERTERM_ID = 10;
 	private static final int PHENO_GENOTYPES_COLUMN_TERM1_SUPERTERM_NAME = 11;
 
 	private static final int PHENO_GENOTYPES_COLUMN_TERM2_SUBTERM_ID = 15;
 	private static final int PHENO_GENOTYPES_COLUMN_TERM2_SUBTERM_NAME = 16;
+	private static final int PHENO_GENOTYPES_COLUMN_TERM2_RELATIONSHIP_ID =17;
+	private static final int PHENO_GENOTYPES_COLUMN_TERM2_RELATIONSHIP_NAME = 18;
 	private static final int PHENO_GENOTYPES_COLUMN_TERM2_SUPERTERM_ID = 19;
 	private static final int PHENO_GENOTYPES_COLUMN_TERM2_SUPERTERM_NAME = 20;
 
@@ -96,11 +100,15 @@ public class ZFINWalker {
 	private static final int PHENO_GENE_COLUMN_ZFIN_GENE_ID = 2;
 	private static final int PHENO_GENE_COLUMN_TERM1_SUBTERM_ID = 3;
 	private static final int PHENO_GENE_COLUMN_TERM1_SUBTERM_NAME = 4;
+	private static final int PHENO_GENE_COLUMN_TERM1_RELATIONSHIP_ID = 5;
+	private static final int PHENO_GENE_COLUMN_TERM1_RELATIONSHIP_NAME = 6;
 	private static final int PHENO_GENE_COLUMN_TERM1_SUPERTERM_ID = 7;
 	private static final int PHENO_GENE_COLUMN_TERM1_SUPERTERM_NAME = 8;
 
 	private static final int PHENO_GENE_COLUMN_TERM2_SUBTERM_ID = 12;
 	private static final int PHENO_GENE_COLUMN_TERM2_SUBTERM_NAME = 13;
+	private static final int PHENO_GENE_COLUMN_TERM2_RELATIONSHIP_ID = 14;
+	private static final int PHENO_GENE_COLUMN_TERM2_RELATIONSHIP_NAME = 15;
 	private static final int PHENO_GENE_COLUMN_TERM2_SUPERTERM_ID = 16;
 	private static final int PHENO_GENE_COLUMN_TERM2_SUPERTERM_NAME = 17;
 
@@ -128,11 +136,15 @@ public class ZFINWalker {
 					entry.entity1SupertermName = sp[PHENO_GENE_COLUMN_TERM1_SUPERTERM_NAME];
 					entry.entity1SubtermId = sp[PHENO_GENE_COLUMN_TERM1_SUBTERM_ID];
 					entry.entity1SubtermName = sp[PHENO_GENE_COLUMN_TERM1_SUBTERM_NAME];
+					entry.entity1RelationshipId = sp[PHENO_GENE_COLUMN_TERM1_RELATIONSHIP_ID];
+					entry.entity1RelationshipName = sp[PHENO_GENE_COLUMN_TERM1_RELATIONSHIP_NAME];
 
 					entry.entity2SupertermId = sp[PHENO_GENE_COLUMN_TERM2_SUPERTERM_ID];
 					entry.entity2SupertermName = sp[PHENO_GENE_COLUMN_TERM2_SUPERTERM_NAME];
 					entry.entity2SubtermId = sp[PHENO_GENE_COLUMN_TERM2_SUBTERM_ID];
 					entry.entity2SubtermName = sp[PHENO_GENE_COLUMN_TERM2_SUBTERM_NAME];
+					entry.entity2RelationshipId = sp[PHENO_GENE_COLUMN_TERM2_RELATIONSHIP_ID];
+					entry.entity2RelationshipName = sp[PHENO_GENE_COLUMN_TERM2_RELATIONSHIP_NAME];
 
 					entry.patoID = sp[PHENO_GENE_COLUMN_PATO_ID];
 					entry.patoName = sp[PHENO_GENE_COLUMN_PATO_NAME];
@@ -148,11 +160,15 @@ public class ZFINWalker {
 					entry.entity1SupertermName = sp[PHENO_GENOTYPES_COLUMN_TERM1_SUPERTERM_NAME];
 					entry.entity1SubtermId = sp[PHENO_GENOTYPES_COLUMN_TERM1_SUBTERM_ID];
 					entry.entity1SubtermName = sp[PHENO_GENOTYPES_COLUMN_TERM1_SUBTERM_NAME];
+					entry.entity1RelationshipId = sp[PHENO_GENOTYPES_COLUMN_TERM1_RELATIONSHIP_ID];
+					entry.entity1RelationshipName = sp[PHENO_GENOTYPES_COLUMN_TERM1_RELATIONSHIP_NAME];
 
 					entry.entity2SupertermId = sp[PHENO_GENOTYPES_COLUMN_TERM2_SUPERTERM_ID];
 					entry.entity2SupertermName = sp[PHENO_GENOTYPES_COLUMN_TERM2_SUPERTERM_NAME];
 					entry.entity2SubtermId = sp[PHENO_GENOTYPES_COLUMN_TERM2_SUBTERM_ID];
 					entry.entity2SubtermName = sp[PHENO_GENOTYPES_COLUMN_TERM2_SUBTERM_NAME];
+					entry.entity2RelationshipId = sp[PHENO_GENOTYPES_COLUMN_TERM2_RELATIONSHIP_ID];
+					entry.entity2RelationshipName = sp[PHENO_GENOTYPES_COLUMN_TERM2_RELATIONSHIP_NAME];
 
 					entry.patoID = sp[PHENO_GENOTYPES_COLUMN_PATO_ID];
 					entry.patoName = sp[PHENO_GENOTYPES_COLUMN_PATO_NAME];
@@ -189,6 +205,10 @@ public class ZFINWalker {
 		StringBuilder source = new StringBuilder();
 		source.append(entry.entity1SupertermId); // affected_structure_or_process_1_superterm_id
 		source.append('\t');
+		if (entry.entity1RelationshipId != null) {
+			source.append(entry.entity1RelationshipId); // affected_structure_or_process_1_relationship_id
+		}
+		source.append('\t');
 		if (entry.entity1SubtermId != null) {
 			source.append(entry.entity1SubtermId); // affected_structure_or_process_1_subterm_id
 		}
@@ -205,6 +225,10 @@ public class ZFINWalker {
 		source.append('\t');
 		if (entry.entity2SupertermId != null) {
 			source.append(entry.entity2SupertermId);// affected_structure_or_process_2_superterm_id
+		}
+		source.append('\t');
+		if (entry.entity2RelationshipId != null) {
+			source.append(entry.entity2RelationshipId); // affected_structure_or_process_2_relationship_id
 		}
 		source.append('\t');
 		if (entry.entity2SubtermId != null) {

--- a/zpgen/src/main/java/de/charite/zpgen/ZPGen.java
+++ b/zpgen/src/main/java/de/charite/zpgen/ZPGen.java
@@ -161,7 +161,6 @@ public class ZPGen {
 
 		// was before BFO_0000070
 		final OWLObjectProperty towards = factory.getOWLObjectProperty(IRI.create(purlOboIRI + "RO_0002503"));
-		final OWLObjectProperty partOf = factory.getOWLObjectProperty(IRI.create(purlOboIRI + "BFO_0000050"));
 
 		// I have for now replaced the BFO-properties with the RO-properties
 		final OWLObjectProperty inheresProperty = factory.getOWLObjectProperty(IRI.create(purlOboIRI + "RO_0000052"));
@@ -255,15 +254,16 @@ public class ZPGen {
 				intersectionList.add(factory.getOWLObjectSomeValuesFrom(has_modifier, abnormal));
 
 				/* Entity 1: Create intersections */
-				if (entry.entity1SubtermId != null && entry.entity1SubtermId.length() > 0) {
+				if (entry.entity1SubtermId != null && entry.entity1SubtermId.length() > 0 && entry.entity1RelationshipId != null && entry.entity1RelationshipId.length() > 0) {
 					/*
 					 * Pattern is (all-some interpretation): <pato> inheres_in
 					 * (<cl2> part of <cl1>) AND qualifier abnormal
 					 */
 					OWLClass cl2 = getEntityClassForOBOID(entry.entity1SubtermId);
+					OWLObjectProperty rel = factory.getOWLObjectProperty(OBOVocabulary.ID2IRI(entry.entity1RelationshipId));
 
 					intersectionList.add(factory.getOWLObjectSomeValuesFrom(inheresProperty,
-							factory.getOWLObjectIntersectionOf(cl2, factory.getOWLObjectSomeValuesFrom(partOf, cl1))));
+							factory.getOWLObjectIntersectionOf(cl2, factory.getOWLObjectSomeValuesFrom(rel, cl1))));
 
 					/*
 					 * Note that is language the last word is the more specific
@@ -285,16 +285,17 @@ public class ZPGen {
 
 					OWLClass cl3 = getEntityClassForOBOID(entry.entity2SupertermId);
 
-					if (entry.entity2SubtermId != null && entry.entity2SubtermId.length() > 0) {
+					if (entry.entity2SubtermId != null && entry.entity2SubtermId.length() > 0 && entry.entity2RelationshipId != null && entry.entity2RelationshipId.length() > 0) {
 						/*
 						 * Pattern is (all-some interpretation): <pato>
 						 * inheres_in (<cl2> part of <cl1>) AND qualifier
 						 * abnormal
 						 */
 						OWLClass cl4 = getEntityClassForOBOID(entry.entity2SubtermId);
+						OWLObjectProperty rel = factory.getOWLObjectProperty(OBOVocabulary.ID2IRI(entry.entity2RelationshipId));
 
 						intersectionList.add(factory.getOWLObjectSomeValuesFrom(towards,
-								factory.getOWLObjectIntersectionOf(cl4, factory.getOWLObjectSomeValuesFrom(partOf, cl3))));
+								factory.getOWLObjectIntersectionOf(cl4, factory.getOWLObjectSomeValuesFrom(rel, cl3))));
 
 						/*
 						 * Note that is language the last word is the more

--- a/zpgen/src/main/java/de/charite/zpgen/ZPGen.java
+++ b/zpgen/src/main/java/de/charite/zpgen/ZPGen.java
@@ -257,7 +257,7 @@ public class ZPGen {
 				if (entry.entity1SubtermId != null && entry.entity1SubtermId.length() > 0 && entry.entity1RelationshipId != null && entry.entity1RelationshipId.length() > 0) {
 					/*
 					 * Pattern is (all-some interpretation): <pato> inheres_in
-					 * (<cl2> part of <cl1>) AND qualifier abnormal
+					 * (<cl2> <rel> <cl1>) AND qualifier abnormal
 					 */
 					OWLClass cl2 = getEntityClassForOBOID(entry.entity1SubtermId);
 					OWLObjectProperty rel = factory.getOWLObjectProperty(OBOVocabulary.ID2IRI(entry.entity1RelationshipId));
@@ -288,7 +288,7 @@ public class ZPGen {
 					if (entry.entity2SubtermId != null && entry.entity2SubtermId.length() > 0 && entry.entity2RelationshipId != null && entry.entity2RelationshipId.length() > 0) {
 						/*
 						 * Pattern is (all-some interpretation): <pato>
-						 * inheres_in (<cl2> part of <cl1>) AND qualifier
+						 * inheres_in (<cl2> <rel> <cl1>) AND qualifier
 						 * abnormal
 						 */
 						OWLClass cl4 = getEntityClassForOBOID(entry.entity2SubtermId);


### PR DESCRIPTION
ZFIN data specify which object property should be used to create post-compositions. Making use of these (instead of always 'part of') clears up the vast majority of unsatisfiable phenotype classes in ZP.