### PR TITLE
Change hostname in IRI for ZFIN source property.

### DIFF
--- a/zpgen/src/main/java/de/charite/zpgen/ZPGen.java
+++ b/zpgen/src/main/java/de/charite/zpgen/ZPGen.java
@@ -423,7 +423,7 @@ public class ZPGen {
 	 * Custom IRI for the annotation property for the definition of the class
 	 * expression.
 	 */
-	static final IRI definitionSourcePropertyIRI = IRI.create("http://zfin/definition/source_information");
+	static final IRI definitionSourcePropertyIRI = IRI.create("http://zfin.org/definition/source_information");
 
 	/**
 	 * Add the source information for the definition of the equivalent class


### PR DESCRIPTION
I'm not sure whether a local hostname really violates the IRI spec, but it seems like this form will be less likely to cause problems.